### PR TITLE
Bug fix for issue at https://github.com/MobileChromeApps/mobile-chrome-a...

### DIFF
--- a/api/app/window.js
+++ b/api/app/window.js
@@ -7,6 +7,7 @@ var Event = require('org.chromium.common.events');
 var mobile = require('org.chromium.bootstrap.mobile.impl');
 var runtime = require('org.chromium.runtime.runtime');
 var ChromeExtensionURLs = require('org.chromium.bootstrap.helpers.ChromeExtensionURLs');
+var backgroundApp = require('org.chromium.backgroundapp.backgroundapp');
 
 // The AppWindow created by chrome.app.window.create.
 var createdAppWindow = null;
@@ -50,8 +51,8 @@ AppWindow.prototype.hide = function() {
   exec(null, null, 'ChromeAppWindow', 'hide', []);
 };
 AppWindow.prototype.show = function(focused) {
-  if (cordova.backgroundapp) {
-    cordova.backgroundapp.show();
+  if (backgroundApp) {
+    backgroundApp.show();
   } else {
     console.warn('window.show() is not supported on this platform');
   }

--- a/api/mobile.js
+++ b/api/mobile.js
@@ -7,6 +7,7 @@ var channel = require('cordova/channel');
 var runtime = require('org.chromium.runtime.runtime');
 var app_runtime = require('org.chromium.runtime.app.runtime');
 var storage = require('org.chromium.storage.Storage');
+var backgroundApp = require('org.chromium.backgroundapp.backgroundapp');
 // Make sure the "isChromeApp" var gets set before replaceState().
 require('org.chromium.common.helpers');
 
@@ -58,7 +59,7 @@ exports.fgInit = function() {
       // If background app plugin is included, handle event to switch from
       // background execution
       document.addEventListener('resume', function() {
-        if (cordova.backgroundapp.resumeType == 'normal-launch') {
+        if (backgroundApp.resumeType == 'normal-launch') {
           fireOnLaunched();
         }
       });


### PR DESCRIPTION
This commit fixes an issue I was having linked above. Where on launch on Android phone, and also when phone moving from 'pause' state, to 'resume' state the org.chromium.backgroundapp was not recognized even though it was installed an listed at runtime. 
 
I have just required the plugin at the top of each script then referenced the var 'backgroundApp'.

I have tested these changes on Android and it works. Something I had been caught on for a few days.